### PR TITLE
git checkout HEAD^2 is no longer necessary

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,8 +17,6 @@ jobs:
       uses: actions/checkout@v2.3.4
       with:
         fetch-depth: 2
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:


### PR DESCRIPTION
Please remove this step as Code Scanning recommends analyzing the merge commit for best results.