### PR TITLE
Allow only one build at a time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: ci
 
+concurrency: ci
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Builds could overtake each other while running in parallel.
This ensures that the docker image really contains the last commit.